### PR TITLE
Fixed minor documentation error

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
 <td>animation-delay: 5</td>
 </tr>
 <tr>
-<td>.vhs-delay-5</td>
+<td>.vhs-delay-6</td>
 <td>animation-delay: 6</td>
 </tr>
 </tbody>


### PR DESCRIPTION
Documentation had a typo indicating the wrong class-name.
